### PR TITLE
Docs: fix typo

### DIFF
--- a/packages/foo-api-docs/docs/lighthouse-check-github-action/configuration.md
+++ b/packages/foo-api-docs/docs/lighthouse-check-github-action/configuration.md
@@ -45,7 +45,7 @@ An endpoint to post comments to. This is only needed if you want to trigger comm
 ### `device`
 **Type**: `'all' | 'desktop' | 'mobile' | undefined`
 
-The device in which to run Lighthouse. **Note**: When specifying `all` - Lighthouse will one multiple times (once per device).
+The device in which to run Lighthouse. **Note**: When specifying `all` - Lighthouse will run multiple times (once per device).
 
 ### `extraHeaders`
 **Type**: `string | undefined`


### PR DESCRIPTION
"one multiple times" -> "run multiple times"