### PR TITLE
Docs - Use GITHUB_TOKEN instead of personal access token 

### DIFF
--- a/packages/foo-api-docs/docs/lighthouse-check-github-action/configuration.md
+++ b/packages/foo-api-docs/docs/lighthouse-check-github-action/configuration.md
@@ -76,7 +76,7 @@ Used in Slack notifications. In a [GitHub context](https://docs.github.com/en/ac
 ### `gitHubAccessToken`
 **Type**: `string | undefined`
 
-[Access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) of a user to post PR comments.
+[GitHub Action Token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) which allows to post PR comments. 
 
 ### `locale`
 **Type**: `string | undefined`

--- a/packages/foo-api-docs/docs/lighthouse-check-github-action/examples.md
+++ b/packages/foo-api-docs/docs/lighthouse-check-github-action/examples.md
@@ -60,7 +60,7 @@ In the below example we do the following:
 - Run Lighthouse on 2 URLs
 - Upload reports to AWS S3.
 - Notify via Slack with details about the change from Git data.
-- By specifying the `pull_request` trigger and `gitHubAccessToken` - we allow automatic comments of audits on the corresponding PR from the token user.
+- By specifying the `pull_request` trigger and `gitHubAccessToken` - we allow automatic comments of audits on the corresponding PR.
 
 ```yaml
 name: Test Lighthouse Check

--- a/packages/foo-api-docs/docs/lighthouse-check-github-action/examples.md
+++ b/packages/foo-api-docs/docs/lighthouse-check-github-action/examples.md
@@ -81,7 +81,7 @@ jobs:
           awsSecretAccessKey: ${{ secrets.LIGHTHOUSE_CHECK_AWS_SECRET_ACCESS_KEY }}
           gitAuthor: ${{ github.actor }}
           gitBranch: ${{ github.ref }}
-          gitHubAccessToken: ${{ secrets.LIGHTHOUSE_CHECK_GITHUB_ACCESS_TOKEN }}
+          gitHubAccessToken: ${{ secrets.GITHUB_TOKEN }}
           outputDirectory: ${{ github.workspace }}/tmp/artifacts
           urls: 'https://www.foo.software,https://www.foo.software/contact'
           sha: ${{ github.sha }}


### PR DESCRIPTION
It's not necessary to use personal Access Token to post a comment on PR. There is automatic token avaliable to each Workflow run which allows that https://docs.github.com/en/actions/security-guides/automatic-token-authentication

Ideally we can updated the action to take the `${{ secrets.GITHUB_TOKEN }}` automatically when users sets `prCommentEnabled` leave the config `gitHubAccessToken` as optional override. 

_In general generating personal access token is too dangerous to be use just like that! Even though there are "beta" tokens with limited access we should definitely go the way of GITHUB_TOKEN instead of that._

<img width="638" alt="image" src="https://github.com/foo-software/foo-api/assets/8086995/821d5359-916f-4ddb-9a1a-9b0e6cffd3df">
